### PR TITLE
Change path to wp-cli-oderland

### DIFF
--- a/repositories.txt
+++ b/repositories.txt
@@ -66,7 +66,7 @@ https://github.com/runcommand/reset-passwords
 https://github.com/sebastiaandegeus/wp-cli-salts-command
 https://github.com/sinebridge/wp-cli-about
 https://github.com/rxnlabs/wp-composer
-https://github.com/sommarnatt/wp-cli-oderland
+https://github.com/oderland/wp-cli-oderland
 https://github.com/srtfisher/wp-composer
 https://github.com/stianlik/wp-cli-mig
 https://github.com/szepeviktor/wp-cli-database-prefix-command


### PR DESCRIPTION
Change from personal github account to organization for wp-cli-oderland.
Now resides at oderland/wp-cli-oderland